### PR TITLE
feat: support find owners endpoint

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -32,3 +32,6 @@ yarn-error.log*
 
 # vercel
 .vercel
+
+# env file
+.env

--- a/web/.prettierignore
+++ b/web/.prettierignore
@@ -5,3 +5,4 @@ out
 .idea
 .gitignore
 .prettierignore
+.env

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -650,6 +650,11 @@
         }
       }
     },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npm.taobao.org/argparse/download/argparse-2.0.1.tgz",
+      "integrity": "sha1-JG9Q88p4oyQPbJl+ipvR6sSeSzg="
+    },
     "arity-n": {
       "version": "1.0.4",
       "resolved": "https://registry.npm.taobao.org/arity-n/download/arity-n-1.0.4.tgz",
@@ -2918,6 +2923,14 @@
       "version": "4.0.0",
       "resolved": "https://registry.npm.taobao.org/js-tokens/download/js-tokens-4.0.0.tgz",
       "integrity": "sha1-GSA/tZmR35jjoocFDUZHzerzJJk="
+    },
+    "js-yaml": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npm.taobao.org/js-yaml/download/js-yaml-4.0.0.tgz?cache=0&sync_timestamp=1609680068452&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fjs-yaml%2Fdownload%2Fjs-yaml-4.0.0.tgz",
+      "integrity": "sha1-9Ca8D/S0BRkmzViMcRExg0CaEh8=",
+      "requires": {
+        "argparse": "^2.0.1"
+      }
     },
     "json-parse-better-errors": {
       "version": "1.0.2",

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "antd": "^4.8.6",
     "axios": "^0.21.0",
+    "js-yaml": "^4.0.0",
     "next": "10.0.5",
     "react": "17.0.1",
     "react-dom": "17.0.1",

--- a/web/pages/[org]/[repo]/pulls/[num]/owners.tsx
+++ b/web/pages/[org]/[repo]/pulls/[num]/owners.tsx
@@ -1,10 +1,18 @@
 import { Tag, Descriptions } from "antd";
 import React from "react";
 import { get } from "@/utils/request";
-import { GITHUB_BASE_URL } from "@/types/constant";
+import {
+  DEFAULT_GITHUB_ENDPOINT,
+  LGTM_CONFIGURATION_KEY,
+  PULL_OWNERS_ENDPOINT_KEY,
+  REPOS_KEY,
+} from "@/types/constant";
 import { OwnersData } from "@/types/owners";
 
 import style from "./owners.module.scss";
+
+const yaml = require("js-yaml");
+const fs = require("fs");
 
 export default function Owners({ org, repo, num, owners }) {
   const ownersData: Partial<OwnersData> = owners.data;
@@ -13,7 +21,7 @@ export default function Owners({ org, repo, num, owners }) {
     return (
       <p className={style.members}>
         {members.map((member) => (
-          <a key={member} href={GITHUB_BASE_URL + member}>
+          <a key={member} href={DEFAULT_GITHUB_ENDPOINT + member}>
             {` @${member} `}
           </a>
         ))}
@@ -26,14 +34,14 @@ export default function Owners({ org, repo, num, owners }) {
       <Descriptions title="PR Owners" bordered>
         <Descriptions.Item label="Repo">
           <Tag color="green">
-            <a href={`${GITHUB_BASE_URL + org}/${repo}`}>
+            <a href={`${DEFAULT_GITHUB_ENDPOINT + org}/${repo}`}>
               {org}/{repo}
             </a>
           </Tag>
         </Descriptions.Item>
         <Descriptions.Item label="PR">
           <Tag color="blue">
-            <a href={`${GITHUB_BASE_URL + org}/${repo}/pull/${num}`}>
+            <a href={`${DEFAULT_GITHUB_ENDPOINT + org}/${repo}/pull/${num}`}>
               {org}/{repo}#{num}
             </a>
           </Tag>
@@ -54,15 +62,56 @@ export default function Owners({ org, repo, num, owners }) {
 
 export async function getServerSideProps(ctx) {
   const { query } = ctx;
-  const { num, org, repo, baseURL } = query;
+  const { num, org, repo } = query;
+
+  const ownersEndpoint = findOwnersEndpoint(
+    process.env["EXTERNAL_PLUGINS_CONFIGS"],
+    org,
+    repo
+  );
+
+  if (ownersEndpoint === null) {
+    throw new Error(`Can not find the owners endpoint of the ${org}/${repo}.`);
+  }
 
   let owners;
   try {
-    owners = await get(`${baseURL}/repos/${org}/${repo}/pulls/${num}/owners`);
+    owners = await get(
+      `${ownersEndpoint}/repos/${org}/${repo}/pulls/${num}/owners`
+    );
   } catch (err) {
     throw err;
   }
+
   return {
     props: { org, repo, num, owners },
   };
+}
+
+/**
+ * Find owners endpoint of the repo.
+ * @param configFilePath The external config file path.
+ * @param org Repo's org.
+ * @param repo Repo's name.
+ */
+function findOwnersEndpoint(
+  configFilePath: string,
+  org: string,
+  repo: string
+): string | null {
+  let ownersURL = null;
+  const externalConfig = yaml.load(fs.readFileSync(configFilePath));
+  const lgtmConfigs = externalConfig[LGTM_CONFIGURATION_KEY];
+
+  lgtmConfigs.forEach((lgtm) => {
+    const repos = lgtm[REPOS_KEY];
+    // Use org name or repo full name.
+    repos.forEach((r) => {
+      if (r === org || r === `${org}/${repo}`) {
+        ownersURL = lgtm[PULL_OWNERS_ENDPOINT_KEY];
+      }
+    });
+  });
+
+  return ownersURL;
 }

--- a/web/pages/[org]/[repo]/pulls/[num]/owners.tsx
+++ b/web/pages/[org]/[repo]/pulls/[num]/owners.tsx
@@ -1,7 +1,7 @@
 import { Tag, Descriptions } from "antd";
 import React from "react";
 import { get } from "@/utils/request";
-import { BASE_URL, GITHUB_BASE_URL } from "@/types/constant";
+import { GITHUB_BASE_URL } from "@/types/constant";
 import { OwnersData } from "@/types/owners";
 
 import style from "./owners.module.scss";
@@ -54,11 +54,11 @@ export default function Owners({ org, repo, num, owners }) {
 
 export async function getServerSideProps(ctx) {
   const { query } = ctx;
-  const { num, org, repo } = query;
+  const { num, org, repo, baseURL } = query;
 
   let owners;
   try {
-    owners = await get(`${BASE_URL}/${org}/${repo}/pulls/${num}/owners`);
+    owners = await get(`${baseURL}/repos/${org}/${repo}/pulls/${num}/owners`);
   } catch (err) {
     throw err;
   }

--- a/web/types/constant.ts
+++ b/web/types/constant.ts
@@ -1,3 +1,4 @@
-export const COMMITTER = "committers";
-export const REVIEWER = "reviewers";
-export const GITHUB_BASE_URL = "https://github.com/";
+export const DEFAULT_GITHUB_ENDPOINT = "https://github.com/";
+export const LGTM_CONFIGURATION_KEY = "ti-community-lgtm";
+export const REPOS_KEY = "repos";
+export const PULL_OWNERS_ENDPOINT_KEY = "pull_owners_endpoint";

--- a/web/types/constant.ts
+++ b/web/types/constant.ts
@@ -1,4 +1,3 @@
-export const BASE_URL = "https://prow.tidb.io/ti-community-owners/repos";
 export const COMMITTER = "committers";
 export const REVIEWER = "reviewers";
 export const GITHUB_BASE_URL = "https://github.com/";


### PR DESCRIPTION
Because we support different owners URL in plugins(such as: community repo's lgtm use `ti-community-bot` as owners service), so the owners page also need to support it.