### PR TITLE
feat: async support for phony-rs

### DIFF
--- a/experiment/phony-rs/Cargo.toml
+++ b/experiment/phony-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phony-rs"
 version = "0.1.0"
-authors = ["hi-rustin <rustin.liu@gmail.com>"]
+authors = ["hi-rustin <rustin.liu@gmail.com>", "Chojan Shang <psiace@outlook.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/experiment/phony-rs/Cargo.toml
+++ b/experiment/phony-rs/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "phony-rs"
 version = "0.1.0"
-authors = ["hi-rustin <rustin.liu@gmail.com>"]
+authors = ["Chojan Shang <psiace@outlook.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rocket = "0.4.6"
-reqwest = { version = "0.10", features = ["blocking", "json"] }
-tokio = { version = "0.2", features = ["full"] }
+warp = "0.3"
+reqwest = { version = "0.11", features = ["json"] }
+tokio = { version = "1.0", features = ["full"] }
 hmac = "0.10.1"
 sha-1 = "0.9.2"
 hex = "0.4"
-rocket_contrib = "0.4.6"
 serde = "1.0"
 serde_derive = "1.0"
 serde_json = "1.0"
+pretty_env_logger = "0.4"

--- a/experiment/phony-rs/Cargo.toml
+++ b/experiment/phony-rs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phony-rs"
 version = "0.1.0"
-authors = ["Chojan Shang <psiace@outlook.com>"]
+authors = ["hi-rustin <rustin.liu@gmail.com>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/experiment/phony-rs/src/main.rs
+++ b/experiment/phony-rs/src/main.rs
@@ -1,37 +1,32 @@
-#![feature(proc_macro_hygiene, decl_macro)]
+use std::convert::Infallible;
 
-#[macro_use]
-extern crate rocket;
 #[macro_use]
 extern crate serde_derive;
 
 use hmac::{Hmac, Mac, NewMac};
-use rocket::http::Status;
-use rocket::response::status;
-use rocket_contrib::json::Json;
-use rocket_contrib::serve::StaticFiles;
 use sha1::Sha1;
+use warp::{self, Filter};
 
 // Create alias for HMAC-SHA1.
 type HmacSha1 = Hmac<Sha1>;
 
-const SHA1_PREFIX: &'static str = "sha1";
+const SHA1_PREFIX: &str = "sha1";
 
 #[derive(Deserialize)]
-struct Event {
-    address: String,
-    event: String,
-    hmac: String,
-    payload: String,
+pub struct Event {
+    pub address: String,
+    pub event: String,
+    pub hmac: String,
+    pub payload: String,
 }
 
-fn send_hook(
+async fn send_hook(
     address: &str,
     event_type: &str,
     hmac: &str,
     payload: &str,
 ) -> Result<String, Box<dyn std::error::Error>> {
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::Client::new();
     let resp = client
         .post(address)
         .body(payload.to_owned())
@@ -42,13 +37,14 @@ fn send_hook(
             sign_payload(payload.as_bytes(), hmac.as_bytes()),
         )
         .header("Content-Type", "application/json")
-        .send()?;
+        .send()
+        .await?;
     if resp.status().is_success() {
-        Ok(resp.text()?)
+        Ok(resp.text().await?)
     } else {
         Ok(format!(
             "Send event success but something wrong: {}",
-            resp.text()?
+            resp.text().await?
         ))
     }
 }
@@ -64,20 +60,34 @@ fn sign_payload(payload: &[u8], key: &[u8]) -> String {
     signature
 }
 
-#[post("/send", data = "<event>")]
-fn send(event: Json<Event>) -> status::Custom<String> {
-    let result = send_hook(&event.address, &event.event, &event.hmac, &event.payload);
+pub async fn send_event(event: Event) -> Result<impl warp::Reply, Infallible> {
+    let result = send_hook(&event.address, &event.event, &event.hmac, &event.payload).await;
     match result {
-        Err(e) => status::Custom(Status::InternalServerError, e.to_string()),
-        Ok(result) => status::Custom(Status::Ok, result),
+        Err(e) => Ok(warp::reply::json(&e.to_string())),
+        Ok(result) => Ok(warp::reply::json(&result)),
     }
 }
 
-fn main() {
-    rocket::ignite()
-        .mount("/", StaticFiles::from("static"))
-        .mount("/events", routes![send])
-        .launch();
+#[tokio::main]
+async fn main() {
+    pretty_env_logger::init();
+
+    let log = warp::log("api::request");
+
+    let files = warp::get()
+        .and(warp::path::end())
+        .and(warp::fs::dir("static"));
+
+    let message = warp::path!("events" / "send")
+        .and(warp::post())
+        .and(warp::body::form())
+        .and_then(send_event);
+
+    let routes = files.or(message);
+
+    warp::serve(routes.with(log))
+        .run(([127, 0, 0, 1], 8000))
+        .await;
 }
 
 #[cfg(test)]

--- a/experiment/phony-rs/static/index.html
+++ b/experiment/phony-rs/static/index.html
@@ -26,11 +26,11 @@
         <div class="row gx-5">
             <div class="col">
                 <form id="eventForm" class="row g-3">
-                    <label class="input-group mb-3">
+                    <div class="input-group mb-3">
                         <span class="input-group-text" id="basic-addon1">Address</span>
                         <input type="text" class="form-control" placeholder="Address" aria-label="Address"
                             aria-describedby="basic-addon1" name="address">
-                    </label>
+                    </div>
                     <div class="input-group mb-3">
                         <span class="input-group-text" id="basic-addon1">Event Type</span>
                         <input type="text" class="form-control" placeholder="Event Type" aria-label="Event Type"

--- a/experiment/phony-rs/static/index.html
+++ b/experiment/phony-rs/static/index.html
@@ -26,11 +26,11 @@
         <div class="row gx-5">
             <div class="col">
                 <form id="eventForm" class="row g-3">
-                    <div class="input-group mb-3">
+                    <label class="input-group mb-3">
                         <span class="input-group-text" id="basic-addon1">Address</span>
                         <input type="text" class="form-control" placeholder="Address" aria-label="Address"
                             aria-describedby="basic-addon1" name="address">
-                    </div>
+                    </label>
                     <div class="input-group mb-3">
                         <span class="input-group-text" id="basic-addon1">Event Type</span>
                         <input type="text" class="form-control" placeholder="Event Type" aria-label="Event Type"
@@ -75,7 +75,7 @@
             $.ajax({
                 type: "POST",
                 url: "/events/send",
-                data: JSON.stringify($('#eventForm').serializeObject()),
+                data: $('#eventForm').serializeObject(),
                 success: function (result) {
                     console.log(JSON.stringify(result));
                 },


### PR DESCRIPTION
- Make phony-rs async.
- Fewer dependencies and faster compilation.

update 2021-01-24:

- async sign payload
- `const SHA1_PREFIX: &str = "sha1=";` Note that the signature format should look like `sha1=7d38cdd689735b008b3c702edd92eea23791c5f6`