### PR TITLE
fix: update dependencies to remove panic

### DIFF
--- a/experiment/label-dumpling/Cargo.toml
+++ b/experiment/label-dumpling/Cargo.toml
@@ -11,7 +11,7 @@ octocrab = "0.8"
 clap = "3.0.0-beta.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8"
-tokio = { version = "0.2.17", default-features = false, features = ["macros"] }
+tokio = { version = "1.0", default-features = false, features = ["macros", "rt-multi-thread"] }
 log = "0.4.0"
-env_logger = "0.8.2"
+pretty_env_logger = "0.4"
 chrono = "0.4"

--- a/experiment/label-dumpling/src/main.rs
+++ b/experiment/label-dumpling/src/main.rs
@@ -37,7 +37,7 @@ struct Label {
 
 #[tokio::main]
 pub async fn main() {
-    env_logger::init();
+    pretty_env_logger::init();
 
     let opts: Opts = Opts::parse();
     let octocrab = octocrab::OctocrabBuilder::new()


### PR DESCRIPTION
fix:
  ```
  thread 'main' panicked at 'not currently running on the Tokio runtime.', github.com-1ecc6299db9ec823/tokio-1.0.2/src/runtime/blocking/pool.rs:84:33
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  ```

It can run normally now.