### PR TITLE
fix: only request reviewers when PR no requested reviewers

### DIFF
--- a/docs/plugins/blunderbuss.md
+++ b/docs/plugins/blunderbuss.md
@@ -16,9 +16,7 @@ ti-community-blunderbuss 负责在 PR 创建时，根据 ti-community-owners 划
 
 该插件主要参考了 Kubernetes 的 blunderbuss 插件设计。在它的基础上，我们依托于 ti-community-owners 实现当前 PR 的 reviewers 自动分配。
 
-当 PR 的 sig 标签发生变化时，插件会取消掉 PR 当前仍然处于 Pending 状态的 reviewers 的请求，重新获取 owners 中的 reviewers, 并重新分配 PR 的 reviewers。
-
-如果一个仓库要求 PR 都带有 sig 标签才能进行自动分配，在 PR 被添加上 sig 相关标签之前，创建 PR、对 PR 评论 `/auto-cc` 命令都不会进行自动分配。
+如果一个仓库要求 PR 带有 sig 标签才能进行自动分配，在 PR 被添加上 sig 相关标签之前，创建 PR、对 PR 评论 `/auto-cc` 命令都不会进行自动分配。当我们打上 sig 标签之后，如果插件检测到没有 reviewers 被分配，插件才会自动的分配 reviewers。
 
 ## 参数配置
 

--- a/docs/plugins/blunderbuss.md
+++ b/docs/plugins/blunderbuss.md
@@ -4,7 +4,7 @@
 
 在 TiDB 社区中，因为一个 PR 会经过多人多阶段 review，所有我们希望能够在 PR 被创建的时候自动分配 reviewers。
 
-ti-community-blunderbuss 负责在 PR 创建时，根据 ti-community-owners 划分的权限自动分配 reviewers。除此之外，我们还需要考虑到如果 reviewers 长时间无回复时需要再次请求其他人 review  的情况，所以我们还支持了 `/auto-cc` 命令来触发再次分配 reviewers。
+ti-community-blunderbuss 负责在 PR 创建时，根据 ti-community-owners 划分的权限自动分配 reviewers。除此之外，我们还需要考虑到如果 reviewers 长时间无回复时需要再次请求其他人 review 的情况，所以我们还支持了 `/auto-cc` 命令来触发再次分配 reviewers。
 
 实际上在一些 TiDB 社区的仓库当中，绝大多数 PR 都需要带有 sig 标签，只有在添加了 sig 标签之后才能够自动分配 reviewers，所以我们需要通过插件加以限制，减少不必要的自动分配。
 
@@ -17,6 +17,8 @@ ti-community-blunderbuss 负责在 PR 创建时，根据 ti-community-owners 划
 该插件主要参考了 Kubernetes 的 blunderbuss 插件设计。在它的基础上，我们依托于 ti-community-owners 实现当前 PR 的 reviewers 自动分配。
 
 如果一个仓库要求 PR 带有 sig 标签才能进行自动分配，那么在 PR 被添加上 sig 相关标签之前，创建 PR、对 PR 评论 `/auto-cc` 命令都不会进行自动分配。当我们打上 sig 标签之后，如果插件检测到没有 reviewers 被分配，插件才会自动的分配 reviewers。
+
+**需要特别注意的是**：当 PR 的 Body 中使用了 `/cc` 命令指定了 reviewers 之后，插件在响应 PR 创建和打上 sig 标签事件时，不会再进行自动分配。但是使用 `/auto-cc` 命令无该限制。
 
 ## 参数配置
 

--- a/docs/plugins/blunderbuss.md
+++ b/docs/plugins/blunderbuss.md
@@ -16,7 +16,7 @@ ti-community-blunderbuss 负责在 PR 创建时，根据 ti-community-owners 划
 
 该插件主要参考了 Kubernetes 的 blunderbuss 插件设计。在它的基础上，我们依托于 ti-community-owners 实现当前 PR 的 reviewers 自动分配。
 
-如果一个仓库要求 PR 带有 sig 标签才能进行自动分配，在 PR 被添加上 sig 相关标签之前，创建 PR、对 PR 评论 `/auto-cc` 命令都不会进行自动分配。当我们打上 sig 标签之后，如果插件检测到没有 reviewers 被分配，插件才会自动的分配 reviewers。
+如果一个仓库要求 PR 带有 sig 标签才能进行自动分配，那么在 PR 被添加上 sig 相关标签之前，创建 PR、对 PR 评论 `/auto-cc` 命令都不会进行自动分配。当我们打上 sig 标签之后，如果插件检测到没有 reviewers 被分配，插件才会自动的分配 reviewers。
 
 ## 参数配置
 

--- a/internal/pkg/externalplugins/blunderbuss/blunderbuss.go
+++ b/internal/pkg/externalplugins/blunderbuss/blunderbuss.go
@@ -108,13 +108,13 @@ func HandlePullRequestEvent(gc githubClient, pe *github.PullRequestEvent,
 	repo := &pe.Repo
 	opts := cfg.BlunderbussFor(repo.Owner.Login, repo.Name)
 	// If there is already /cc, the author has specified reviewers.
-	openPrWithoutCcCommand := !assign.CCRegexp.MatchString(pr.Body)
+	prBodyWithoutCcCommand := !assign.CCRegexp.MatchString(pr.Body)
 
 	isPrLabeledEvent := pe.Action == github.PullRequestActionLabeled
 	openPrWithSigLabel := pe.PullRequest.State == "open" && strings.Contains(pe.Label.Name, externalplugins.SigPrefix)
 
 	// Only handle the event of add SIG label to the open PR.
-	if isPrLabeledEvent && openPrWithSigLabel && openPrWithoutCcCommand {
+	if isPrLabeledEvent && openPrWithSigLabel && prBodyWithoutCcCommand {
 		return handle(
 			gc,
 			opts,
@@ -129,7 +129,7 @@ func HandlePullRequestEvent(gc githubClient, pe *github.PullRequestEvent,
 	repoNonRequireSigLabel := !opts.RequireSigLabel
 
 	// Only handle the event of opening non-CC PR, when the require_sig_label option is not turned on.
-	if isPrOpenedEvent && repoNonRequireSigLabel && openPrWithoutCcCommand {
+	if isPrOpenedEvent && repoNonRequireSigLabel && prBodyWithoutCcCommand {
 		// Wait a few seconds to allow other automation plugin to apply labels (Mainly SIG label).
 		gracePeriod := time.Duration(opts.GracePeriodDuration) * time.Second
 		sleep(gracePeriod)

--- a/internal/pkg/externalplugins/blunderbuss/blunderbuss_test.go
+++ b/internal/pkg/externalplugins/blunderbuss/blunderbuss_test.go
@@ -364,6 +364,15 @@ func TestHandlePullRequest(t *testing.T) {
 			expectReviewerCount: 0,
 		},
 		{
+			name:                "add new sig label for open PR with /cc",
+			action:              github.PullRequestActionLabeled,
+			state:               "open",
+			body:                "/cc @hi-rustin",
+			label:               "sig/planner",
+			maxReviewersCount:   2,
+			expectReviewerCount: 0,
+		},
+		{
 			name:   "add new sig label for open PR contained pending reviewers",
 			action: github.PullRequestActionLabeled,
 			state:  "open",

--- a/internal/pkg/externalplugins/blunderbuss/blunderbuss_test.go
+++ b/internal/pkg/externalplugins/blunderbuss/blunderbuss_test.go
@@ -42,28 +42,6 @@ func (c *fakeGitHubClient) GetPullRequest(_, _ string, _ int) (*github.PullReque
 	return c.pr, nil
 }
 
-func (c *fakeGitHubClient) UnrequestReview(_, _ string, _ int, unRequestReviewerLogins []string) error {
-	var remainReviewers []string
-
-	for _, requestedReviewerLogin := range c.requested {
-		existed := false
-		for _, unRequestReviewerLogin := range unRequestReviewerLogins {
-			if requestedReviewerLogin == unRequestReviewerLogin {
-				existed = true
-				break
-			}
-		}
-
-		if !existed {
-			remainReviewers = append(remainReviewers, requestedReviewerLogin)
-		}
-	}
-
-	c.requested = remainReviewers
-
-	return nil
-}
-
 func (c *fakeGitHubClient) GetIssueLabels(_, _ string, _ int) ([]github.Label, error) {
 	return c.pr.Labels, nil
 }
@@ -356,7 +334,6 @@ func TestHandlePullRequest(t *testing.T) {
 			excludeReviewers: []string{
 				"collab2",
 			},
-
 			expectReviewerCount: 1,
 		},
 		{
@@ -397,7 +374,7 @@ func TestHandlePullRequest(t *testing.T) {
 				"admin1",
 			},
 			maxReviewersCount:   2,
-			expectReviewerCount: 2,
+			expectReviewerCount: 1,
 		},
 	}
 
@@ -574,7 +551,7 @@ func TestHelpProvider(t *testing.T) {
 	}
 }
 
-func TestContainIssueLabels(t *testing.T) {
+func TestContainSigLabels(t *testing.T) {
 	testcases := []struct {
 		name        string
 		labelNames  []string


### PR DESCRIPTION
Part of https://github.com/ti-community-infra/tichi/issues/315

Because we support multiple sigs and in practice we find that people assign revewers manually, we need to stop auto-assignment when there are manually assigned viewers. This feature is similar to not auto-assigning when we have /cc.