### PR TITLE
chore: remove TODO

### DIFF
--- a/internal/pkg/externalplugins/config.go
+++ b/internal/pkg/externalplugins/config.go
@@ -369,7 +369,6 @@ func (c *Configuration) setDefaults() {
 
 // Validate will return an error if there are any invalid external plugin config.
 func (c *Configuration) Validate() error {
-	// TODO: Put the setDefaults function in a more suitable place.
 	// Defaulting should run before validation.
 	c.setDefaults()
 


### PR DESCRIPTION
close https://github.com/ti-community-infra/tichi/issues/231

I thought about it carefully and it actually makes sense to put the setting defaults in this position. Because they have to be set before the validate, and each plugin checks the file. So each plugin sets the defaults.