### PR TITLE
fix: refine tars query

### DIFF
--- a/configs/prow-dev/config/plugins.yaml
+++ b/configs/prow-dev/config/plugins.yaml
@@ -99,6 +99,7 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
+        - push
     - name: ti-community-label-blocker
       events:
         - pull_request

--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -222,8 +222,7 @@ func HandlePushEvent(log *logrus.Entry, ghc githubClient, pe *github.PushEvent,
 
 	var buf bytes.Buffer
 	fmt.Fprint(&buf, "archived:false is:pr is:open sort:created-asc")
-	fmt.Fprintf(&buf, " org:\"%s\"", org)
-	fmt.Fprintf(&buf, " repo:\"%s\"", repo)
+	fmt.Fprintf(&buf, " repo:\"%s/%s\"", org, repo)
 	fmt.Fprintf(&buf, " base:\"%s\"", branch)
 
 	prs, err := search(context.Background(), log, ghc, buf.String())

--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -21,7 +21,7 @@ const (
 	PluginName = "ti-community-tars"
 	// branchRefsPrefix specifies the prefix of branch refs.
 	// See also: https://docs.github.com/en/rest/reference/git#references.
-	branchRefsPrefix = "refs/heads"
+	branchRefsPrefix = "refs/heads/"
 )
 
 const configInfoAutoUpdatedMessagePrefix = "Auto updated message: "


### PR DESCRIPTION
log look like:
{"event-GUID":"e70a40f6-7a56-11eb-9920-5b7df3cfafa3","event-type":"push","level":"info","msg":"Search for query \"archived:false is:pr is:open sort:created-asc org:\"ti-community-infra\" repo:\"test-dev\" base:\"/master\"\" cost 3 point(s). 4975 remaining.","plugin":"ti-community-tars","time":"2021-03-01T06:25:23Z"}
{"event-GUID":"e70a40f6-7a56-11eb-9920-5b7df3cfafa3","event-type":"push","level":"info","msg":"Considering 0 PRs.","plugin":"ti-community-tars","time":"2021-03-01T06:25:23Z"}
{"event-GUID":"e76c35b8-7a56-11eb-95cd-da45d7f2c8d6","event-type":"push","level":"info","msg":"Checking ti-community-infra/test-dev#/testaddeee PRs.","plugin":"ti-community-tars","time":"2021-03-01T06:25:23Z"}
{"event-GUID":"e76c35b8-7a56-11eb-95cd-da45d7f2c8d6","event-type":"push","level":"info","msg":"Search for query \"archived:false is:pr is:open sort:created-asc org:\"ti-community-infra\" repo:\"test-dev\" base:\"/testaddeee\"\" cost 3 point(s). 4972 remaining.","plugin":"ti-community-tars","time":"2021-03-01T06:25:23Z"}