### PR TITLE
fix: check PR mergeable for tars

### DIFF
--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -241,7 +241,7 @@ func HandlePushEvent(log *logrus.Entry, ghc githubClient, pe *github.PushEvent,
 			"pr":   num,
 		})
 
-		// Skips PRs that cannot be conflicting or unknown state.
+		// Skips PRs with conflicting or unknown status.
 		if pr.Mergeable != githubql.MergeableStateMergeable {
 			continue
 		}
@@ -295,7 +295,7 @@ func HandleAll(log *logrus.Entry, ghc githubClient, config *plugins.Configuratio
 			"repo": repo,
 			"pr":   num,
 		})
-		// Skips PRs that cannot be conflicting or unknown state.
+		// Skips PRs with conflicting or unknown status.
 		if pr.Mergeable != githubql.MergeableStateMergeable {
 			continue
 		}

--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -245,10 +245,10 @@ func HandlePushEvent(log *logrus.Entry, ghc githubClient, pe *github.PushEvent,
 		if pr.Mergeable != githubql.MergeableStateMergeable {
 			continue
 		}
-		tryUpdate, err := handle(l, ghc, &pr, cfg)
+		takenAction, err := handle(l, ghc, &pr, cfg)
 		if err != nil {
 			l.WithError(err).Error("Error handling PR.")
-		} else if tryUpdate {
+		} else if takenAction {
 			// Only one PR is processed at a time, because even if other PRs are updated,
 			// they still need to be queued for another update and merge.
 			// To save testing resources we only process one PR at a time.

--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -72,7 +72,7 @@ type pullRequest struct {
 			Name githubql.String
 		}
 	} `graphql:"labels(first:100)"`
-	Merged githubql.Boolean
+	Mergeable githubql.MergeableState
 }
 
 type searchQuery struct {
@@ -301,7 +301,8 @@ func HandleAll(log *logrus.Entry, ghc githubClient, config *plugins.Configuratio
 }
 
 func handle(log *logrus.Entry, ghc githubClient, pr *pullRequest, cfg *externalplugins.Configuration) error {
-	if pr.Merged {
+	// Skips PRs that cannot be conflicting.
+	if pr.Mergeable != githubql.MergeableStateMergeable {
 		return nil
 	}
 

--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -241,10 +241,6 @@ func HandlePushEvent(log *logrus.Entry, ghc githubClient, pe *github.PushEvent,
 			"pr":   num,
 		})
 
-		// Only one PR is processed at a time, because even if other PRs are updated,
-		// they still need to be queued for another update and merge.
-		// To save testing resources we only process one PR at a time.
-
 		// Skips PRs that cannot be conflicting or unknown state.
 		if pr.Mergeable != githubql.MergeableStateMergeable {
 			continue
@@ -253,6 +249,9 @@ func HandlePushEvent(log *logrus.Entry, ghc githubClient, pe *github.PushEvent,
 		if err != nil {
 			l.WithError(err).Error("Error handling PR.")
 		} else {
+			// Only one PR is processed at a time, because even if other PRs are updated,
+			// they still need to be queued for another update and merge.
+			// To save testing resources we only process one PR at a time.
 			break
 		}
 	}


### PR DESCRIPTION
When there is a PR conflict, the API call to update the PR does not report an error, so it causes the mechanism to update the PR after the push event to fail.