### PR TITLE
fix: Use MergeStateStatus to reduce the use of tars for the GitHub API

### DIFF
--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -215,6 +215,9 @@ func HandlePushEvent(log *logrus.Entry, ghc githubClient, pe *github.PushEvent,
 		return nil
 	}
 
+	// Before checking state wait a few seconds to give github a chance to calculate it.
+	sleep(time.Minute)
+
 	org := pe.Repo.Owner.Login
 	repo := pe.Repo.Name
 	branch := getRefBranch(pe.Ref)

--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -215,7 +215,7 @@ func HandlePushEvent(log *logrus.Entry, ghc githubClient, pe *github.PushEvent,
 		return nil
 	}
 
-	// Before checking state wait a few seconds to give github a chance to calculate it.
+	// Before checking state wait a minute to give github a chance to calculate it.
 	sleep(time.Minute)
 
 	org := pe.Repo.Owner.Login

--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -25,7 +25,7 @@ const (
 	// See also: https://docs.github.com/en/rest/reference/git#references.
 	branchRefsPrefix = "refs/heads/"
 	// behind means the head ref is out of date.
-	// See also: https://docs.github.com/en/graphql/reference/enums#mergestatestatus
+	// See also: https://docs.github.com/en/graphql/reference/enums#mergestatestatus.
 	behind = "BEHIND"
 )
 

--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -326,7 +326,7 @@ func handle(log *logrus.Entry, ghc githubClient, pr *pullRequest, cfg *tiexterna
 		return false, nil
 	}
 
-	if !(pr.MergeStateStatus == behind) {
+	if pr.MergeStateStatus != behind {
 		return false, nil
 	}
 

--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -25,7 +25,7 @@ const (
 	// See also: https://docs.github.com/en/rest/reference/git#references.
 	branchRefsPrefix = "refs/heads/"
 	// behind means the head ref is out of date.
-	// See also: https://docs.github.com/en/graphql/reference/enums#mergeablestate
+	// See also: https://docs.github.com/en/graphql/reference/enums#mergestatestatus
 	behind = "BEHIND"
 )
 

--- a/internal/pkg/externalplugins/tars/tars_test.go
+++ b/internal/pkg/externalplugins/tars/tars_test.go
@@ -613,7 +613,7 @@ func TestHandlePushEvent(t *testing.T) {
 			// For now we only add one pr.
 			var prs []pullRequest
 			if tc.pr != nil {
-				prs = generatePullRequests("org1", "repo1", tc.pr, tc.prCommits, tc.labels)
+				prs = generatePullRequests("org1", "repo1", tc.pr, tc.prCommits, tc.labels, tc.outOfDate)
 			}
 			fc := newFakeGithubClient(prs, tc.pr, tc.baseCommit, tc.prCommits, tc.outOfDate)
 			externalConfig := &externalplugins.Configuration{}
@@ -771,7 +771,7 @@ func TestHandleAll(t *testing.T) {
 			// For now we only add one pr.
 			var prs []pullRequest
 			if tc.pr != nil {
-				prs = generatePullRequests("org", "repo", tc.pr, tc.prCommits, tc.labels)
+				prs = generatePullRequests("org", "repo", tc.pr, tc.prCommits, tc.labels, tc.outOfDate)
 			}
 			fc := newFakeGithubClient(prs, tc.pr, tc.baseCommit, tc.prCommits, tc.outOfDate)
 			cfg := &plugins.Configuration{
@@ -794,7 +794,7 @@ func TestHandleAll(t *testing.T) {
 }
 
 func generatePullRequests(org string, repo string, pr *github.PullRequest,
-	prCommits []github.RepositoryCommit, labels []github.Label) []pullRequest {
+	prCommits []github.RepositoryCommit, labels []github.Label, outOfDate bool) []pullRequest {
 	var prs []pullRequest
 
 	graphPr := pullRequest{}
@@ -840,6 +840,12 @@ func generatePullRequests(org string, repo string, pr *github.PullRequest,
 	}
 
 	graphPr.Commits.Nodes = append(graphPr.Commits.Nodes, graphCommit)
+	// Set the merge stats state.
+	if outOfDate {
+		graphPr.MergeStateStatus = behind
+	} else {
+		graphPr.MergeStateStatus = "UNKNOWN"
+	}
 	prs = append(prs, graphPr)
 
 	return prs

--- a/internal/pkg/externalplugins/tars/tars_test.go
+++ b/internal/pkg/externalplugins/tars/tars_test.go
@@ -840,7 +840,7 @@ func generatePullRequests(org string, repo string, pr *github.PullRequest,
 	}
 
 	graphPr.Commits.Nodes = append(graphPr.Commits.Nodes, graphCommit)
-	// Set the merge stats state.
+	// Set the merge state status.
 	if outOfDate {
 		graphPr.MergeStateStatus = behind
 	} else {


### PR DESCRIPTION
Maybe fix https://github.com/ti-community-infra/tichi/issues/411

```release-note
Use MergeStateStatus to reduce the use of tars for the GitHub API.
```