### PR TITLE
fix: tars wait a few seconds after receiving a comment

### DIFF
--- a/internal/pkg/externalplugins/tars/tars.go
+++ b/internal/pkg/externalplugins/tars/tars.go
@@ -133,6 +133,12 @@ func HandleIssueCommentEvent(log *logrus.Entry, ghc githubClient, ice *github.Is
 	if !ice.Issue.IsPullRequest() {
 		return nil
 	}
+
+	// Delay for a few seconds to give GitHub time to add or remove the label,
+	// as the comment may be a command related to a PR merge(such as /hold or /merge).
+	// See: https://github.com/ti-community-infra/tichi/issues/524.
+	sleep(time.Second * 5)
+
 	pr, err := ghc.GetPullRequest(ice.Repo.Owner.Login, ice.Repo.Name, ice.Issue.Number)
 	if err != nil {
 		return err


### PR DESCRIPTION
close https://github.com/ti-community-infra/tichi/issues/524

```release-note
tars wait a few seconds after receiving a comment.
```