### PR TITLE
fix: tars stop pass the expectedHeadSha and use the default value

### DIFF
--- a/configs/prow-dev/cluster/deck_deployment.yaml
+++ b/configs/prow-dev/cluster/deck_deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - --github-graphql-endpoint=http://ghproxy/graphql
             - --plugin-config=/etc/plugins/plugins.yaml
             - --spyglass=true
-            - --dry-run=true
+            - --dry-run=false
             - --job-config-path=/etc/job-config
           ports:
             - name: http

--- a/configs/prow-dev/cluster/sinker_deployment.yaml
+++ b/configs/prow-dev/cluster/sinker_deployment.yaml
@@ -22,6 +22,7 @@ spec:
           args:
             - --config-path=/etc/config/config.yaml
             - --job-config-path=/etc/job-config
+            - --dry-run=false
           volumeMounts:
             - name: config
               mountPath: /etc/config


### PR DESCRIPTION
```release-note
tars stop pass the expectedHeadSha and use the default value.
```

GitHub falsely reports mismatch when we pass that value, so we use the default value.