### PR TITLE
config(test-dev): stop block LGT labels

### DIFF
--- a/configs/prow-dev/config/external_plugins_config.yaml
+++ b/configs/prow-dev/config/external_plugins_config.yaml
@@ -68,13 +68,6 @@ ti-community-label-blocker:
   - repos:
       - ti-community-infra/test-dev
     block_labels:
-      - regex: "^status/LGT[\\d]+$"
-        actions:
-          - labeled
-        trusted_teams:
-          - bots-test
-        trusted_users:
-          - mini-bot
       - regex: "^status/can-merge$"
         actions:
           - labeled


### PR DESCRIPTION
It is difficult to review during testing, so we need to stop the blocker.