### PR TITLE
fix(rerere): Check every minute

### DIFF
--- a/internal/pkg/rerere/rerere.go
+++ b/internal/pkg/rerere/rerere.go
@@ -27,7 +27,7 @@ const (
 )
 
 // defaultCheckPeriod specifies the default period for test ticker.
-var defaultCheckPeriod = time.Minute * 5
+var defaultCheckPeriod = time.Minute * 1
 
 // Ref: https://docs.github.com/en/rest/reference/checks#create-a-check-run--parameters.
 const (


### PR DESCRIPTION
Five minutes is too long. I think 1 minute is fine based on our current token usage.