### PR TITLE
build: Bump golangci-lint from 1.31.0 to 1.41.1

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -20,5 +20,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.31
+          version: v1.41.1
           args: --timeout=500s

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,18 +10,17 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
+    - revive
     - goprintffuncname
     - gosec
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
     - misspell
     - nolintlint
     - rowserrcheck
-    - scopelint
+    - exportloopref
     - staticcheck
     - structcheck
     - typecheck

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ staticcheck: tools/bin/golangci-lint
 	tools/bin/golangci-lint run  $$($(PACKAGE_DIRECTORIES)) --timeout 500s
 
 tools/bin/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.31.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.41.1
 
 label-dumpling-checks:
 	@echo "label-dumpling checks"

--- a/cmd/check-external-plugin-config/main.go
+++ b/cmd/check-external-plugin-config/main.go
@@ -72,9 +72,6 @@ func validate(o options) error {
 	if err := yaml.Unmarshal(bytes, config); err != nil {
 		return err
 	}
-	if err := config.Validate(); err != nil {
-		return err
-	}
 
-	return nil
+	return config.Validate()
 }

--- a/internal/pkg/externalplugins/config.go
+++ b/internal/pkg/externalplugins/config.go
@@ -534,11 +534,7 @@ func (c *Configuration) Validate() error {
 		return err
 	}
 
-	if err := validateTars(c.TiCommunityTars); err != nil {
-		return err
-	}
-
-	return nil
+	return validateTars(c.TiCommunityTars)
 }
 
 // validateLogLevel will return an error if the value of the log level is invalid.


### PR DESCRIPTION
The old version hasn't ARM architecture binary package for Mac (M1).