### PR TITLE
fix: fix the commenter query format

### DIFF
--- a/configs/prow-dev/jobs/ti-community-infra/test-dev/rustin-bot-periodics.yaml
+++ b/configs/prow-dev/jobs/ti-community-infra/test-dev/rustin-bot-periodics.yaml
@@ -11,9 +11,7 @@ periodics:
             - /app/robots/commenter/app.binary
           args:
             - |-
-              --query=repo:ti-community-infra/test-dev
-              -label:lifecycle/frozen
-              label:lifecycle/rotten
+              --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen label:lifecycle/rotten
             - --updated=720h
             - --token=/etc/github/token
             - |-
@@ -47,10 +45,7 @@ periodics:
             - /app/robots/commenter/app.binary
           args:
             - |-
-              --query=repo:ti-community-infra/test-dev
-              -label:lifecycle/frozen
-              label:lifecycle/stale
-              -label:lifecycle/rotten
+              --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen label:lifecycle/stale -label:lifecycle/rotten
             - --updated=720h
             - --token=/etc/github/token
             - |-
@@ -86,10 +81,7 @@ periodics:
             - /app/robots/commenter/app.binary
           args:
             - |-
-              --query=repo:ti-community-infra/test-dev
-              -label:lifecycle/frozen
-              -label:lifecycle/stale
-              -label:lifecycle/rotten
+              --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen -label:lifecycle/stale -label:lifecycle/rotten
             - --updated=2160h
             - --token=/etc/github/token
             - |-

--- a/configs/prow-dev/jobs/ti-community-infra/test-dev/rustin-bot-periodics.yaml
+++ b/configs/prow-dev/jobs/ti-community-infra/test-dev/rustin-bot-periodics.yaml
@@ -10,8 +10,7 @@ periodics:
           command:
             - /app/robots/commenter/app.binary
           args:
-            - |-
-              --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen label:lifecycle/rotten
+            - --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen label:lifecycle/rotten
             - --updated=720h
             - --token=/etc/github/token
             - |-
@@ -44,8 +43,7 @@ periodics:
           command:
             - /app/robots/commenter/app.binary
           args:
-            - |-
-              --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen label:lifecycle/stale -label:lifecycle/rotten
+            - --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen label:lifecycle/stale -label:lifecycle/rotten
             - --updated=720h
             - --token=/etc/github/token
             - |-
@@ -80,8 +78,7 @@ periodics:
           command:
             - /app/robots/commenter/app.binary
           args:
-            - |-
-              --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen -label:lifecycle/stale -label:lifecycle/rotten
+            - --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen -label:lifecycle/stale -label:lifecycle/rotten
             - --updated=2160h
             - --token=/etc/github/token
             - |-


### PR DESCRIPTION
Fix the problem that lifecycle commenter throw 422 error.

```
2021/07/16 07:24:12 main.go:213: Searching: org:ti-community-infra
-label:lifecycle/frozen
-label:lifecycle/stale
-label:lifecycle/rotten archived:false is:open updated:<=2021-04-17T07:24:12Z
time="2021-07-16T07:24:12Z" level=info msg="FindIssues(org:ti-community-infra\n-label:lifecycle/frozen\n-label:lifecycle/stale\n-label:lifecycle/rotten archived:false is:open updated:<=2021-04-17T07:24:12Z)" client=github
2021/07/16 07:24:12 main.go:194: Failed run: search failed: status code 422 not one of [200], body: {"message":"Validation Failed","errors":[{"message":"The listed users and repositories cannot be searched either because the resources do not exist or you do not have permission to view them.","resource":"Search","field":"q","code":"invalid"}],"documentation_url":"https://docs.github.com/v3/search/"}
```