### PR TITLE
fix(cherrypicker): fix failed to fetch private repo problem

### DIFF
--- a/cmd/ticommunitycherrypicker/main.go
+++ b/cmd/ticommunitycherrypicker/main.go
@@ -111,10 +111,11 @@ func main() {
 	}
 
 	server := &cherrypicker.Server{
-		TokenGenerator: secretAgent.GetTokenGenerator(o.webhookSecretFile),
-		BotUser:        botUser,
-		Email:          email,
-		ConfigAgent:    epa,
+		WebhookSecretGenerator: secretAgent.GetTokenGenerator(o.webhookSecretFile),
+		GitHubTokenGenerator:   secretAgent.GetTokenGenerator(o.github.TokenPath),
+		BotUser:                botUser,
+		Email:                  email,
+		ConfigAgent:            epa,
 
 		GitClient:    git.ClientFactoryFrom(gitClient),
 		GitHubClient: githubClient,

--- a/internal/pkg/externalplugins/cherrypicker/cherrypicker.go
+++ b/internal/pkg/externalplugins/cherrypicker/cherrypicker.go
@@ -582,10 +582,8 @@ func (s *Server) handle(logger *logrus.Entry, requestor string,
 			ex := exec.New()
 			dir := r.Directory()
 
-			// Add the upstream remote.
-			upstreamURL := fmt.Sprintf("%s/%s", s.GitHubURL, pr.Base.Repo.FullName)
-
 			// Warning: Do not output url with authorization information to the log and response.
+			upstreamURL := fmt.Sprintf("%s/%s", s.GitHubURL, pr.Base.Repo.FullName)
 			upstreamURLWithAuth, err := url.Parse(upstreamURL)
 			if err != nil {
 				logger.WithError(err).Errorf("Failed to remote parse url: %s", upstreamURL)
@@ -593,6 +591,7 @@ func (s *Server) handle(logger *logrus.Entry, requestor string,
 			}
 			upstreamURLWithAuth.User = url.UserPassword(s.BotUser.Login, string(s.GitHubTokenGenerator()))
 
+			// Add the upstream remote.
 			addUpstreamRemote := ex.Command("git", "remote", "add", upstreamRemoteName, upstreamURLWithAuth.String())
 			addUpstreamRemote.SetDir(dir)
 			out, err := addUpstreamRemote.CombinedOutput()

--- a/internal/pkg/externalplugins/cherrypicker/cherrypicker.go
+++ b/internal/pkg/externalplugins/cherrypicker/cherrypicker.go
@@ -27,6 +27,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"regexp"
 	"strings"
@@ -157,9 +158,10 @@ func HelpProvider(epa *tiexternalplugins.ConfigAgent) externalplugins.ExternalPl
 // Server implements http.Handler. It validates incoming GitHub webhooks and
 // then dispatches them to the appropriate plugins.
 type Server struct {
-	TokenGenerator func() []byte
-	BotUser        *github.UserData
-	Email          string
+	WebhookSecretGenerator func() []byte
+	GitHubTokenGenerator   func() []byte
+	BotUser                *github.UserData
+	Email                  string
 
 	GitClient git.ClientFactory
 	// Used for unit testing
@@ -188,7 +190,7 @@ type cherryPickRequest struct {
 
 // ServeHTTP validates an incoming webhook and puts it into the event channel.
 func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.TokenGenerator)
+	eventType, eventGUID, payload, ok, _ := github.ValidateWebhook(w, r, s.WebhookSecretGenerator)
 	if !ok {
 		return
 	}
@@ -582,12 +584,21 @@ func (s *Server) handle(logger *logrus.Entry, requestor string,
 
 			// Add the upstream remote.
 			upstreamURL := fmt.Sprintf("%s/%s", s.GitHubURL, pr.Base.Repo.FullName)
-			addUpstreamRemote := ex.Command("git", "remote", "add", upstreamRemoteName, upstreamURL)
+
+			// Warning: Do not output url with authorization information to the log and response.
+			upstreamURLWithAuth, err := url.Parse(upstreamURL)
+			if err != nil {
+				logger.WithError(err).Errorf("Failed to remote parse url: %s", upstreamURL)
+				errs = append(errs, fmt.Errorf("failed to parse remote url: %s", upstreamURL))
+			}
+			upstreamURLWithAuth.User = url.UserPassword(s.BotUser.Login, string(s.GitHubTokenGenerator()))
+
+			addUpstreamRemote := ex.Command("git", "remote", "add", upstreamRemoteName, upstreamURLWithAuth.String())
 			addUpstreamRemote.SetDir(dir)
 			out, err := addUpstreamRemote.CombinedOutput()
 			if err != nil {
 				logger.WithError(err).Warnf("Failed to git remote add %s and the output look like: %s.", upstreamURL, out)
-				errs = append(errs, fmt.Errorf("failed to git remote add: %w", err))
+				errs = append(errs, fmt.Errorf("failed to git remote add %s %s", upstreamRemoteName, upstreamURL))
 			}
 
 			// Fetch the upstream remote.
@@ -596,7 +607,7 @@ func (s *Server) handle(logger *logrus.Entry, requestor string,
 			out, err = fetchUpstreamRemote.CombinedOutput()
 			if err != nil {
 				logger.WithError(err).Warnf("Failed to fetch %s remote and the output look like: %s.", upstreamRemoteName, out)
-				errs = append(errs, fmt.Errorf("failed to git fetch upstream: %w", err))
+				errs = append(errs, fmt.Errorf("failed to git fetch %s", upstreamRemoteName))
 			}
 
 			//  Try git cherry-pick.

--- a/internal/pkg/externalplugins/cherrypicker/cherrypicker_test.go
+++ b/internal/pkg/externalplugins/cherrypicker/cherrypicker_test.go
@@ -347,6 +347,10 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 		return []byte("sha=abcdefg")
 	}
 
+	getGithubToken := func() []byte {
+		return []byte("token")
+	}
+
 	cfg := &externalplugins.Configuration{}
 	cfg.TiCommunityCherrypicker = []externalplugins.TiCommunityCherrypicker{
 		{
@@ -359,14 +363,15 @@ func testCherryPickIC(clients localgit.Clients, t *testing.T) {
 	ca.Set(cfg)
 
 	s := &Server{
-		BotUser:        botUser,
-		GitClient:      c,
-		ConfigAgent:    ca,
-		Push:           func(forkName, newBranch string, force bool) error { return nil },
-		GitHubClient:   ghc,
-		TokenGenerator: getSecret,
-		Log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-		Repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+		BotUser:                botUser,
+		GitClient:              c,
+		ConfigAgent:            ca,
+		Push:                   func(forkName, newBranch string, force bool) error { return nil },
+		GitHubClient:           ghc,
+		WebhookSecretGenerator: getSecret,
+		GitHubTokenGenerator:   getGithubToken,
+		Log:                    logrus.StandardLogger().WithField("client", "cherrypicker"),
+		Repos:                  []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 	}
 
 	if err := s.handleIssueComment(logrus.NewEntry(logrus.StandardLogger()), ic); err != nil {
@@ -464,6 +469,10 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 		return []byte("sha=abcdefg")
 	}
 
+	getGithubToken := func() []byte {
+		return []byte("token")
+	}
+
 	testCases := []struct {
 		name        string
 		labelPrefix string
@@ -536,14 +545,15 @@ func testCherryPickPRWithLabels(clients localgit.Clients, t *testing.T) {
 			ca.Set(cfg)
 
 			s := &Server{
-				BotUser:        botUser,
-				GitClient:      c,
-				ConfigAgent:    ca,
-				Push:           func(forkName, newBranch string, force bool) error { return nil },
-				GitHubClient:   ghc,
-				TokenGenerator: getSecret,
-				Log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-				Repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+				BotUser:                botUser,
+				GitClient:              c,
+				ConfigAgent:            ca,
+				Push:                   func(forkName, newBranch string, force bool) error { return nil },
+				GitHubClient:           ghc,
+				WebhookSecretGenerator: getSecret,
+				GitHubTokenGenerator:   getGithubToken,
+				Log:                    logrus.StandardLogger().WithField("client", "cherrypicker"),
+				Repos:                  []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 			}
 
 			if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
@@ -730,6 +740,10 @@ func testCherryPickPRWithComment(clients localgit.Clients, t *testing.T) {
 		return []byte("sha=abcdefg")
 	}
 
+	getGithubToken := func() []byte {
+		return []byte("token")
+	}
+
 	cfg := &externalplugins.Configuration{}
 	cfg.TiCommunityCherrypicker = []externalplugins.TiCommunityCherrypicker{
 		{
@@ -741,14 +755,15 @@ func testCherryPickPRWithComment(clients localgit.Clients, t *testing.T) {
 	ca.Set(cfg)
 
 	s := &Server{
-		BotUser:        botUser,
-		GitClient:      c,
-		ConfigAgent:    ca,
-		Push:           func(forkName, newBranch string, force bool) error { return nil },
-		GitHubClient:   ghc,
-		TokenGenerator: getSecret,
-		Log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-		Repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+		BotUser:                botUser,
+		GitClient:              c,
+		ConfigAgent:            ca,
+		Push:                   func(forkName, newBranch string, force bool) error { return nil },
+		GitHubClient:           ghc,
+		WebhookSecretGenerator: getSecret,
+		GitHubTokenGenerator:   getGithubToken,
+		Log:                    logrus.StandardLogger().WithField("client", "cherrypicker"),
+		Repos:                  []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 	}
 
 	if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr); err != nil {
@@ -860,6 +875,10 @@ func testCherryPickPRLabeled(clients localgit.Clients, t *testing.T) {
 		return []byte("sha=abcdefg")
 	}
 
+	getGithubToken := func() []byte {
+		return []byte("token")
+	}
+
 	testCases := []struct {
 		name         string
 		labelPrefix  string
@@ -963,14 +982,15 @@ func testCherryPickPRLabeled(clients localgit.Clients, t *testing.T) {
 					ca.Set(cfg)
 
 					s := &Server{
-						BotUser:        botUser,
-						GitClient:      c,
-						ConfigAgent:    ca,
-						Push:           func(forkName, newBranch string, force bool) error { return nil },
-						GitHubClient:   ghc,
-						TokenGenerator: getSecret,
-						Log:            logrus.StandardLogger().WithField("client", "cherrypicker"),
-						Repos:          []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
+						BotUser:                botUser,
+						GitClient:              c,
+						ConfigAgent:            ca,
+						Push:                   func(forkName, newBranch string, force bool) error { return nil },
+						GitHubClient:           ghc,
+						WebhookSecretGenerator: getSecret,
+						GitHubTokenGenerator:   getGithubToken,
+						Log:                    logrus.StandardLogger().WithField("client", "cherrypicker"),
+						Repos:                  []github.Repo{{Fork: true, FullName: "ci-robot/bar"}},
 					}
 
 					if err := s.handlePullRequest(logrus.NewEntry(logrus.StandardLogger()), pr(lb)); err != nil {
@@ -1389,7 +1409,7 @@ foo/bar:
 		}
 
 		s := Server{
-			TokenGenerator: getSecret,
+			WebhookSecretGenerator: getSecret,
 		}
 
 		s.ServeHTTP(w, r)
@@ -1489,8 +1509,8 @@ foo/bar:
 		ca.Set(cfg)
 
 		s := Server{
-			TokenGenerator: getSecret,
-			ConfigAgent:    ca,
+			WebhookSecretGenerator: getSecret,
+			ConfigAgent:            ca,
 		}
 
 		s.ServeHTTP(w, r)


### PR DESCRIPTION
When a conflict occurs in the process of cherrypicker pick PR, a `fetch upstream` operation is required, which will cause errors to the private repository before.