### PR TITLE
fix(merge): If the commit hash is not found, check each commit

### DIFF
--- a/internal/pkg/externalplugins/merge/merge.go
+++ b/internal/pkg/externalplugins/merge/merge.go
@@ -377,7 +377,8 @@ func isLGTMSatisfy(prefix string, labels []github.Label, needsLgtm int) bool {
 func isAllGuaranteed(prCommits []github.RepositoryCommit, lastCanMergeTreeHash string, log *logrus.Entry) bool {
 	guaranteed := true
 
-	lastGuaranteedIndex := 0
+	// NOTICE: We use -1 here because it is possible that the user recommitted all commits.
+	lastGuaranteedIndex := -1
 	for i, commit := range prCommits {
 		if commit.SHA == lastCanMergeTreeHash {
 			lastGuaranteedIndex = i

--- a/internal/pkg/externalplugins/merge/merge_test.go
+++ b/internal/pkg/externalplugins/merge/merge_test.go
@@ -1100,6 +1100,16 @@ func TestAllGuaranteed(t *testing.T) {
 		expectGuaranteed bool
 	}{
 		{
+			name:            "No guaranteed commit",
+			lastCanMergeSha: treeSHA,
+			commits: []github.RepositoryCommit{
+				{
+					SHA: "no-guaranteed",
+				},
+			},
+			expectGuaranteed: false,
+		},
+		{
 			name:            "Only one commit",
 			lastCanMergeSha: treeSHA,
 			commits: []github.RepositoryCommit{

--- a/internal/pkg/externalplugins/merge/merge_test.go
+++ b/internal/pkg/externalplugins/merge/merge_test.go
@@ -646,6 +646,9 @@ func TestHandlePullRequest(t *testing.T) {
 			prCommits: map[string][]github.RepositoryCommit{
 				prName: {
 					{
+						SHA: SHA,
+					},
+					{
 						SHA: treeSHA,
 					},
 				},
@@ -684,6 +687,9 @@ func TestHandlePullRequest(t *testing.T) {
 					{
 						SHA: SHA,
 					},
+					{
+						SHA: treeSHA,
+					},
 				},
 			},
 			IssueLabelsRemoved: []string{externalplugins.CanMergeLabel},
@@ -720,6 +726,9 @@ func TestHandlePullRequest(t *testing.T) {
 			},
 			prCommits: map[string][]github.RepositoryCommit{
 				prName: {
+					{
+						SHA: SHA,
+					},
 					{
 						SHA: treeSHA,
 					},

--- a/internal/pkg/externalplugins/merge/merge_test.go
+++ b/internal/pkg/externalplugins/merge/merge_test.go
@@ -646,7 +646,7 @@ func TestHandlePullRequest(t *testing.T) {
 			prCommits: map[string][]github.RepositoryCommit{
 				prName: {
 					{
-						SHA: SHA,
+						SHA: treeSHA,
 					},
 				},
 			},
@@ -721,7 +721,7 @@ func TestHandlePullRequest(t *testing.T) {
 			prCommits: map[string][]github.RepositoryCommit{
 				prName: {
 					{
-						SHA: SHA,
+						SHA: treeSHA,
 					},
 				},
 			},


### PR DESCRIPTION
If the commit hash is not found, check each commit.

A bad case: https://github.com/pingcap/ticdc/pull/2717