### PR TITLE
config: make dependabot do update weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,5 @@ updates:
 - package-ecosystem: npm
   directory: "/web"
   schedule:
-    interval: daily
+    interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
Daily update is too heavy for daily maintenance work, so it is modified to a weekly update.