### PR TITLE
feat: format checker support skip label option

### DIFF
--- a/docs/en/plugins/format-checker.md
+++ b/docs/en/plugins/format-checker.md
@@ -18,7 +18,7 @@ The plugin will use regular expressions to verify the title and content of the P
 ### RequiredMatchRule
 
 | Parameter name  | Type   | Description                                                                                                                          |
-|-----------------|--------|-- - ---------------------------------------------------------------------------------------------------------------------------------|
+|-----------------|--------|--------------------------------------------------------------------------------------------------------------------------------------|
 | pull_request    | bool   | Whether to verify the PR                                                                                                             |
 | issue           | bool   | Whether to verify the issue                                                                                                          |
 | title           | bool   | Whether to verify the title part of the PR or issue                                                                                  |
@@ -27,6 +27,7 @@ The plugin will use regular expressions to verify the title and content of the P
 | regexp          | string | Regular expression used in verification                                                                                              |
 | missing_message | string | When the match fails, comment and reply to the PR or issue, and the prompt information of multiple rules will be aggregated together |
 | missing_label   | string | The label added to PR or issue when the match fails                                                                                  |
+| skip_label      | string | Specify the label that can skip the current rule check                                                                               |
 
 The regular expressions in the matching rules can be used to perform additional checks on specific parts by [named group](https://pkg.go.dev/regexp#Regexp.SubexpNames). The currently supported named groups are as follows:
 
@@ -46,7 +47,10 @@ ti-community-format-checker:
           Please follow PR Title Format: `[TI-<issue_number>] pkg, pkg2, pkg3: what is changed`
           Or if the count of mainly changed packages are more than 3, use `[TI-<issue_number>] *: what is changed`
         missing_label: do-not-merge/invalid-title
+        skip_label: skip-issue
 ```
+
+Notice: If you want to use the matching rule as a check item that must be passed before merging, you need to set `missing_label` value as the `missingLabels` option of the [tide](en/components/tide) component and the `exclude_labels` option of [tars](en/plugins/tars) plugin.
 
 ## Reference Documents
 

--- a/docs/plugins/format-checker.md
+++ b/docs/plugins/format-checker.md
@@ -25,9 +25,9 @@
 | body            | bool   | 是否对  PR 或 issue 的内容部分进行校验                                    |
 | commit_message  | bool   | 是否对 PR 当中 commit 的 commit message 部分进行校验                      |
 | regexp          | string | 校验时使用的正则表达式                                                    |
-| missing_message | string | 当匹配失败时，对 PR 或 issue 进行评论回复，多个规则的提示信息会聚合在一起 |
+| missing_message | string | 当匹配失败时，对 PR 或 issue 进行评论回复，多个规则的提示信息会聚合在一起        |
 | missing_label   | string | 当匹配失败时，对 PR 或 issue 添加的标签                                   |
-
+| skip_label      | string | 指定能够跳过当前检查规则的标签                                             ｜
 
 匹配规则当中的正则表达式可以通过 [命名分组](https://pkg.go.dev/regexp#Regexp.SubexpNames) 的方式对特定部分进行额外的检查，目前支持的命名分组如下：
 
@@ -47,7 +47,10 @@ ti-community-format-checker:
           Please follow PR Title Format: `[TI-<issue_number>] pkg, pkg2, pkg3: what is changed`
           Or if the count of mainly changed packages are more than 3, use `[TI-<issue_number>] *: what is changed`
         missing_label: do-not-merge/invalid-title
+        skip_label: skip-issue
 ```
+
+注意: 如果想把匹配规则作为合并前必须通过的检查项，需要将 `missing_label` 设置为 [tide](components/tide) 组件的 `missingLabels` 选项，以及 [tars](plugins/tars) 插件的 `exclude_labels` 选项。
 
 ## 参考文档
 

--- a/internal/pkg/externalplugins/config.go
+++ b/internal/pkg/externalplugins/config.go
@@ -289,6 +289,8 @@ type RequiredMatchRule struct {
 	MissingMessage string `json:"missing_message,omitempty"`
 	// MissingLabel specifies the label added by the bot when there is no match.
 	MissingLabel string `json:"missing_label,omitempty"`
+	// SkipLabel specifies the label added by the contributor for skipping the format checking.
+	SkipLabel string `json:"skip_label,omitempty"`
 }
 
 // LgtmFor finds the Lgtm for a repo, if one exists

--- a/internal/pkg/externalplugins/formatchecker/formatchecker.go
+++ b/internal/pkg/externalplugins/formatchecker/formatchecker.go
@@ -129,11 +129,11 @@ func HandlePullRequestEvent(gc githubClient, pe *github.PullRequestEvent,
 	repo := pe.Repo.Name
 	num := pe.Number
 
-	blocker := cfg.FormatCheckerFor(org, repo)
+	checker := cfg.FormatCheckerFor(org, repo)
 	needCheckCommits := false
 	rulesForPullRequest := make([]tiexternalplugins.RequiredMatchRule, 0)
 	skipLabels := sets.NewString()
-	for _, rule := range blocker.RequiredMatchRules {
+	for _, rule := range checker.RequiredMatchRules {
 		if rule.PullRequest {
 			rulesForPullRequest = append(rulesForPullRequest, rule)
 			skipLabels.Insert(rule.SkipLabel)

--- a/internal/pkg/externalplugins/formatchecker/formatchecker.go
+++ b/internal/pkg/externalplugins/formatchecker/formatchecker.go
@@ -183,7 +183,7 @@ func HandleIssueEvent(gc githubClient, ie *github.IssueEvent,
 	if ie.Action != github.IssueActionOpened && ie.Action != github.IssueActionEdited &&
 		ie.Action != github.IssueActionReopened && ie.Action != github.IssueActionLabeled &&
 		ie.Action != github.IssueActionUnlabeled {
-		log.Debug("Skipping because not an valid issue action.")
+		log.Debug("Skipping because not a valid issue action.")
 		return nil
 	}
 

--- a/internal/pkg/externalplugins/formatchecker/formatchecker_test.go
+++ b/internal/pkg/externalplugins/formatchecker/formatchecker_test.go
@@ -25,11 +25,13 @@ func TestHandlePullRequestEvent(t *testing.T) {
 	}
 
 	testcases := []struct {
-		name               string
-		action             github.PullRequestEventAction
-		title              string
-		body               string
-		label              string
+		name   string
+		action github.PullRequestEventAction
+		// label is label labeled or unlabeled.
+		label string
+		title string
+		body  string
+		// labels is the labels existed on the pull request.
 		labels             []string
 		commitMessages     []string
 		requiredMatchRules []externalplugins.RequiredMatchRule
@@ -342,6 +344,25 @@ func TestHandlePullRequestEvent(t *testing.T) {
 			},
 			expectDeletedLabels: []string{},
 		},
+		{
+			name:   "Labeled the other label, do not trigger the check",
+			action: github.PullRequestActionLabeled,
+			label:  "other",
+			title:  "pkg: what's changed",
+			labels: []string{},
+			requiredMatchRules: []externalplugins.RequiredMatchRule{
+				{
+					PullRequest:  true,
+					Title:        true,
+					Regexp:       issueTitleRegex,
+					MissingLabel: "do-not-merge/invalid-title",
+					SkipLabel:    "skip-issue",
+				},
+			},
+
+			expectAddedLabels:   []string{},
+			expectDeletedLabels: []string{},
+		},
 	}
 
 	for _, testcase := range testcases {
@@ -643,6 +664,25 @@ func TestHandleIssueEvent(t *testing.T) {
 			expectAddedLabels: []string{
 				formattedLabel("do-not-merge/invalid-title"),
 			},
+			expectDeletedLabels: []string{},
+		},
+		{
+			name:   "Labeled the other label, do not trigger the check",
+			action: github.IssueActionLabeled,
+			label:  "other",
+			title:  "pkg: what's changed",
+			labels: []string{},
+			requiredMatchRules: []externalplugins.RequiredMatchRule{
+				{
+					Issue:        true,
+					Title:        true,
+					Regexp:       issueTitleRegex,
+					MissingLabel: "do-not-merge/invalid-title",
+					SkipLabel:    "skip-issue",
+				},
+			},
+
+			expectAddedLabels:   []string{},
 			expectDeletedLabels: []string{},
 		},
 	}

--- a/internal/pkg/externalplugins/formatchecker/formatchecker_test.go
+++ b/internal/pkg/externalplugins/formatchecker/formatchecker_test.go
@@ -27,11 +27,11 @@ func TestHandlePullRequestEvent(t *testing.T) {
 	testcases := []struct {
 		name   string
 		action github.PullRequestEventAction
-		// label is label labeled or unlabeled.
+		// label that will be labeled or unlabeled.
 		label string
 		title string
 		body  string
-		// labels is the labels existed on the pull request.
+		// labels is the labels existed on the pull request (after the labeled / unlabeled event happened).
 		labels             []string
 		commitMessages     []string
 		requiredMatchRules []externalplugins.RequiredMatchRule
@@ -468,11 +468,13 @@ func TestHandleIssueEvent(t *testing.T) {
 	}
 
 	testcases := []struct {
-		name               string
-		action             github.IssueEventAction
-		label              string
-		title              string
-		body               string
+		name   string
+		action github.IssueEventAction
+		// label that will be labeled or unlabeled.
+		label string
+		title string
+		body  string
+		// labels is the labels existed on the pull request (after the labeled / unlabeled event happened).
 		labels             []string
 		commitMessages     []string
 		requiredMatchRules []externalplugins.RequiredMatchRule


### PR DESCRIPTION
close https://github.com/ti-community-infra/tichi/issues/768

- An option for each matching rule is provided. For example, contributors can skip the issue number check for some PRs that do not have to provide related issues by adding skip label. 
- When contributors labeled the skip label, pass the rule
- When contributors unlabeled the skip label, recheck the rule
- When contributors labeled / unlabeled the other label, do not trigger the check