### PR TITLE
feat(externalplugins/issuetriage): support wont fix feature

### DIFF
--- a/docs/en/plugins/issue-triage.md
+++ b/docs/en/plugins/issue-triage.md
@@ -47,9 +47,10 @@ When the `check-issue-triage-complete` check passes, the bot removes the `do-not
 ## Parameter Configuration
 
 | parameter name                  | type     | description                                                                         |
-|---------------------------------|----------|-------------------------------------------------------------------------------------|
+| ------------------------------- | -------- | ----------------------------------------------------------------------------------- |
 | repos                           | []string | Configuration effective repository                                                  |
 | maintain_versions               | []string | The version number of the release branch being maintained by the repository         |
+| wontfix_versions                | []string | The version number of the release branch won't be cherry pick to in the repository  |
 | affects_label_prefix            | string   | The label prefix that identifies the release branch affected by the issue           |
 | may_affects_label_prefix        | string   | The label prefix that identifies the release branch that the issue may affect       |
 | linked_issue_needs_triage_label | string   | The label that identifies the PR's associated issue that requires triage completion |
@@ -66,6 +67,8 @@ ti-community-issue-triage:
       - "5.1"
       - "5.2"
       - "5.3"
+    wontfix_versions:
+      - "5.1" # can label `affect-5.1` label to issue, but will not create `needs-cherry-pick-5.1` in pull request.
     affects_label_prefix: "affects/"
     may_affects_label_prefix: "may-affects/"
     linked_issue_needs_triage_label: "do-not-merge/needs-triage_completed"

--- a/docs/plugins/issue-triage.md
+++ b/docs/plugins/issue-triage.md
@@ -46,15 +46,16 @@ ti-community-issue-triage 插件将被设计来对以上流程进行管控和自
 
 ## 参数配置 
 
-| 参数名                             | 类型       | 说明                                   |
-|---------------------------------|----------|--------------------------------------|
-| repos                           | []string | 配置生效仓库                               |
-| maintain_versions               | []string | 仓库正在维护的发行分支版本号                       |
-| affects_label_prefix            | string   | 标识 issue 影响的发行分支的 label 前缀           |
-| may_affects_label_prefix        | string   | 标识 issue 可能影响的发行分支的 label 前缀         |
-| linked_issue_needs_triage_label | string   | 标识 PR 所关联 issue 需要 triage 完成的 label  |
-| need_cherry_pick_label_prefix   | string   | 标识 PR 需要 cherry-pick 到 release 分支的前缀 |
-| status_target_url               | string   | Status check 的详情 URL                 |
+| 参数名                          | 类型     | 说明                                                   |
+| ------------------------------- | -------- | ------------------------------------------------------ |
+| repos                           | []string | 配置生效仓库                                           |
+| maintain_versions               | []string | 仓库正在维护的发行分支版本号                           |
+| wontfix_versions                | []string | 仓库不会再自动创建 cherry pick PR 的目标发行分支版本号 |
+| affects_label_prefix            | string   | 标识 issue 影响的发行分支的 label 前缀                 |
+| may_affects_label_prefix        | string   | 标识 issue 可能影响的发行分支的 label 前缀             |
+| linked_issue_needs_triage_label | string   | 标识 PR 所关联 issue 需要 triage 完成的 label          |
+| need_cherry_pick_label_prefix   | string   | 标识 PR 需要 cherry-pick 到 release 分支的前缀         |
+| status_target_url               | string   | Status check 的详情 URL                                |
 
 例如：
 
@@ -66,6 +67,8 @@ ti-community-issue-triage:
       - "5.1"
       - "5.2"
       - "5.3"
+    wontfix_versions:
+      - "5.1" # issue 会打上 `affect-5.1` 标签, 但 PR 不会自动打上 `needs-cherry-pick-5.1` 标签.      
     affects_label_prefix: "affects/"
     may_affects_label_prefix: "may-affects/"
     linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"

--- a/internal/pkg/externalplugins/config.go
+++ b/internal/pkg/externalplugins/config.go
@@ -309,8 +309,10 @@ type RequiredMatchRule struct {
 type TiCommunityIssueTriage struct {
 	// Repos are either of the form org/repo or just org.
 	Repos []string `json:"repos,omitempty"`
-	// MaintainVersions specifies the version number under maintenance, like 5.1.
+	// MaintainVersions specifies the version numbers under maintenance, like 5.1.
 	MaintainVersions []string `json:"maintain_versions"`
+	// WontfixVersions specifies the version numbers out of fix support, like 5.0.
+	WontfixVersions []string `json:"wontfix_versions"`
 	// AffectsLabelPrefix specifies the prefix for the affects label
 	AffectsLabelPrefix string `json:"affects_label_prefix"`
 	// MayAffectsLabelPrefix specifies the prefix for the may-affects label

--- a/internal/pkg/externalplugins/issuetriage/issuetriage_test.go
+++ b/internal/pkg/externalplugins/issuetriage/issuetriage_test.go
@@ -1870,6 +1870,7 @@ func TestHelpProvider(t *testing.T) {
 					{
 						Repos:                     []string{"org2/repo"},
 						MaintainVersions:          []string{"5.1", "5.2", "5.3"},
+						WontfixVersions:           []string{"5.1", "5.2"},
 						NeedCherryPickLabelPrefix: "needs-cherry-pick-release-",
 						AffectsLabelPrefix:        "affects/",
 						MayAffectsLabelPrefix:     "may-affects/",
@@ -1885,6 +1886,8 @@ func TestHelpProvider(t *testing.T) {
 				"The need triaged label prefix is:",
 				"The need cherry-pick label prefix is:",
 				"The status details will be targeted to:",
+				"The release branches that the current repository is maintaining:",
+				"The release branches won't fix in the current repository:",
 			},
 			configInfoExcludes: []string{},
 		},

--- a/internal/pkg/externalplugins/issuetriage/issuetriage_test.go
+++ b/internal/pkg/externalplugins/issuetriage/issuetriage_test.go
@@ -841,6 +841,42 @@ func TestHandlePullRequestEvent(t *testing.T) {
 			expectCreatedStatusDesc:  statusDescAllBugIssueTriaged,
 		},
 		{
+			name:         "open a pull request linked to two triaged issue, but affect labels contain won't fix versions",
+			action:       github.PullRequestActionOpened,
+			labels:       []string{},
+			body:         "Issue Number: close #2, ref #3",
+			state:        "open",
+			targetBranch: "master",
+			issues: map[int]*github.Issue{
+				2: {
+					Number: 2,
+					Labels: []github.Label{
+						{Name: "type/bug"},
+						{Name: "severity/major"},
+						{Name: "affects/5.2"},
+						{Name: "affects/4.1"},
+					},
+				},
+				3: {
+					Number: 3,
+					Labels: []github.Label{
+						{Name: "type/bug"},
+						{Name: "severity/major"},
+						{Name: "affects/5.3"},
+						{Name: "affects/4.0"},
+					},
+				},
+			},
+
+			expectAddedLabels: []string{
+				"org/repo#1:needs-cherry-pick-release-5.2",
+				"org/repo#1:needs-cherry-pick-release-5.3",
+			},
+			expectRemovedLabels:      []string{},
+			expectCreatedStatusState: github.StatusSuccess,
+			expectCreatedStatusDesc:  statusDescAllBugIssueTriaged,
+		},
+		{
 			name:         "open a pull request on release branch and link to a bug issue with may-affects/* labels",
 			action:       github.PullRequestActionOpened,
 			labels:       []string{},
@@ -933,7 +969,8 @@ func TestHandlePullRequestEvent(t *testing.T) {
 		cfg.TiCommunityIssueTriage = []externalplugins.TiCommunityIssueTriage{
 			{
 				Repos:                     []string{"org/repo"},
-				MaintainVersions:          []string{"5.1", "5.2", "5.3"},
+				MaintainVersions:          []string{"4.0", "4.1", "5.1", "5.2", "5.3"},
+				WontfixVersions:           []string{"4.0", "4.1"},
 				AffectsLabelPrefix:        "affects/",
 				MayAffectsLabelPrefix:     "may-affects/",
 				NeedTriagedLabel:          "do-not-merge/needs-triage-completed",
@@ -1831,10 +1868,8 @@ func TestHelpProvider(t *testing.T) {
 			config: &externalplugins.Configuration{
 				TiCommunityIssueTriage: []externalplugins.TiCommunityIssueTriage{
 					{
-						Repos: []string{"org2/repo"},
-						MaintainVersions: []string{
-							"5.1", "5.2", "5.3",
-						},
+						Repos:                     []string{"org2/repo"},
+						MaintainVersions:          []string{"5.1", "5.2", "5.3"},
 						NeedCherryPickLabelPrefix: "needs-cherry-pick-release-",
 						AffectsLabelPrefix:        "affects/",
 						MayAffectsLabelPrefix:     "may-affects/",


### PR DESCRIPTION
Close issue: #996 

- will not add `needs-cherry-pick-x.y` label to PR if `x.y` is in wont fix versions