### PR TITLE
ci: fix job's container command after image upgraded

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -184,7 +184,7 @@ postsubmits:
       containers:
         - image: gcr.io/k8s-prow/label_sync:v20221104-4497ace285
           command:
-            - /app/label_sync/app.binary
+            - /ko-app/label_sync
           args:
             - --config=configs/prow-dev/config/labels.yaml
             - --confirm=true

--- a/configs/prow-dev/jobs/ti-community-infra/test-dev/rustin-bot-periodics.yaml
+++ b/configs/prow-dev/jobs/ti-community-infra/test-dev/rustin-bot-periodics.yaml
@@ -8,7 +8,7 @@ periodics:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20221104-4497ace285
           command:
-            - /app/robots/commenter/app.binary
+            - /ko-app/commenter
           args:
             - --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen label:lifecycle/rotten
             - --updated=720h
@@ -41,7 +41,7 @@ periodics:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20221104-4497ace285
           command:
-            - /app/robots/commenter/app.binary
+            - /ko-app/commenter
           args:
             - --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen label:lifecycle/stale -label:lifecycle/rotten
             - --updated=720h
@@ -76,7 +76,7 @@ periodics:
       containers:
         - image: gcr.io/k8s-prow/commenter:v20221104-4497ace285
           command:
-            - /app/robots/commenter/app.binary
+            - /ko-app/commenter
           args:
             - --query=repo:ti-community-infra/test-dev -label:lifecycle/frozen -label:lifecycle/stale -label:lifecycle/rotten
             - --updated=2160h


### PR DESCRIPTION
- job: post-tichi-label-sync
- image: gcr.io/k8s-prow/label_sync