### PR TITLE
fix(deps): bump image ticommunityinfra/tide to v20221207-9225e3a153

### DIFF
--- a/configs/prow-dev/cluster/tide_deployment.yaml
+++ b/configs/prow-dev/cluster/tide_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: ticommunityinfra/tide:v20220130-v1.0.4
+          image: ticommunityinfra/tide:v20221207-9225e3a153
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml


### PR DESCRIPTION
- built with https://github.com/ti-community-infra/test-infra/tree/upgrade-tide-with-hacks