### PR TITLE
feat(issuetriage): support fresh the status by `/retest` command

### DIFF
--- a/configs/prow-dev/config/external_plugins_config.yaml
+++ b/configs/prow-dev/config/external_plugins_config.yaml
@@ -83,7 +83,7 @@ ti-community-label-blocker:
           - mini-bot
           - zuo-bot-1
         message: |
-          You can't add the `do-not-merge/needs-triage-completed` label, please rerun the check with `/run-check-issue-triage-complete`.
+          You can't add the `do-not-merge/needs-triage-completed` label, please rerun the check with `/retest` or `/run-check-issue-triage-complete`.
 
 ti-community-contribution:
   - repos:
@@ -128,8 +128,7 @@ ti-community-format-checker:
         body: true
         branches:
           - master
-        regexp:
-          "(?im)^Issue
+        regexp: "(?im)^Issue
           Number:\\s*((,\\s*)?(ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\\s*((https|http)://github\\.com/{{.Org}}/{{.Repo}}/issues/|{{.Org}}/{{.Repo}}#|#)(?P<issue_number>[1-9]\\d*))+"
         missing_message: |
           **Notice**: To remove the `do-not-merge/needs-linked-issue` label, please provide the linked issue number on one line in the PR body, for example: `Issue Number: close #123` or `Issue Number: ref #456`.
@@ -154,7 +153,6 @@ ti-community-issue-triage:
     linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"
     need_cherry_pick_label_prefix: "needs-cherry-pick-release-"
     status_target_url: "https://book.prow.tidb.net/#/en/plugins/issue-triage"
-
 
 ti-community-blunderbuss:
   - repos:

--- a/docs/en/plugins/issue-triage.md
+++ b/docs/en/plugins/issue-triage.md
@@ -26,7 +26,7 @@ For critical or major severity bug issues.
 
 For pull requests that fix related bug issues and linked with them, we add a check named `check-issue-triage-complete` that will ensure that the bug issues are triaged before the pull request is merged.
 
-By default, the plugin will trigger the check at the right time, and if it doesn't, contributors can trigger it manually with the `/run-check-issue-triage-complete` or `/check-issue-triage-complete` command.
+By default, the plugin will trigger the check at the right time, and if it doesn't, contributors can trigger it manually with the `/retest` or `/run-check-issue-triage-complete` or `/check-issue-triage-complete` command.
 
 The plugin determines whether a pull request is triaged according to the following rules.
 
@@ -42,7 +42,7 @@ The plugin determines whether a pull request is triaged according to the followi
 
 If `check-issue-triage-complete` does not pass, the bot will automatically label `do-not-merge/needs-triage-completed` to prevent the PR from merging.
 
-When the `check-issue-triage-complete` check passes, the bot removes the `do-not-merge/needs-triage-completed` label and automatically labels the PR with `needs- cherry-pick-release-x.y` labels for all associated bug issues.
+When the `check-issue-triage-complete` check passes, the bot removes the `do-not-merge/needs-triage-completed` label and automatically labels the PR with `needs-cherry-pick-release-x.y` labels for all associated bug issues.
 
 ## Parameter Configuration
 
@@ -80,4 +80,3 @@ ti-community-issue-triage:
 
 - [0625-new-triage-method-for-cherrypick.md](https://github.com/pingcap/community/blob/master/votes/0625-new-triage-method-for- cherrypick.md)
 - [code](https://github.com/ti-community-infra/tichi/tree/master/internal/pkg/externalplugins/issuetriage)
-

--- a/docs/plugins/issue-triage.md
+++ b/docs/plugins/issue-triage.md
@@ -26,7 +26,7 @@ ti-community-issue-triage 插件将被设计来对以上流程进行管控和自
 
 对于修复相关 bug issue 并与之关联的 pull request 而言，我们会添加一个名为 `check-issue-triage-complete` 的检查项，该检查将会确保 bug issue 在 pull request 合并之前完成 triage。
 
-默认情况下，插件会在合适的时机来触发该检查，如果没有触发成功，Contributor 可以通过 `/run-check-issue-triage-complete` 或 `/check-issue-triage-complete` 命令进行手动触发。
+默认情况下，插件会在合适的时机来触发该检查，如果没有触发成功，Contributor 可以通过 `/retest` 或 `/run-check-issue-triage-complete` 或 `/check-issue-triage-complete` 命令进行手动触发。
 
 插件会根据如下规则来判断 pull request 是否完成 triaged：
 
@@ -44,7 +44,7 @@ ti-community-issue-triage 插件将被设计来对以上流程进行管控和自
 
 当 `check-issue-triage-complete` 检查通过时，机器人会去掉 `do-not-merge/needs-triage-completed` 标签，并根据所有关联的 bug issue 的 `affects-x.y` 标签为 PR 自动打上 `needs-cherry-pick-release-x.y` 标签。
 
-## 参数配置 
+## 参数配置
 
 | 参数名                          | 类型     | 说明                                                   |
 | ------------------------------- | -------- | ------------------------------------------------------ |
@@ -68,7 +68,7 @@ ti-community-issue-triage:
       - "5.2"
       - "5.3"
     wontfix_versions:
-      - "5.1" # issue 会打上 `affect-5.1` 标签, 但 PR 不会自动打上 `needs-cherry-pick-5.1` 标签.      
+      - "5.1" # issue 会打上 `affect-5.1` 标签, 但 PR 不会自动打上 `needs-cherry-pick-5.1` 标签.
     affects_label_prefix: "affects/"
     may_affects_label_prefix: "may-affects/"
     linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"
@@ -80,4 +80,3 @@ ti-community-issue-triage:
 
 - [0625-new-triage-method-for-cherrypick.md](https://github.com/pingcap/community/blob/master/votes/0625-new-triage-method-for-cherrypick.md)
 - [code](https://github.com/ti-community-infra/tichi/tree/master/internal/pkg/externalplugins/issuetriage)
-

--- a/internal/pkg/externalplugins/issuetriage/issuetriage.go
+++ b/internal/pkg/externalplugins/issuetriage/issuetriage.go
@@ -49,7 +49,7 @@ const (
 
 var (
 	IssueNumberLineRe   = regexp.MustCompile("(?im)^Issue Number:.+")
-	checkIssueTriagedRe = regexp.MustCompile(`(?mi)^/(run-)?check-issue-triage-complete\s*$`)
+	checkIssueTriagedRe = regexp.MustCompile(`(?mi)^/(retest|(run-)?check-issue-triage-complete)\s*$`)
 )
 
 type githubClient interface {
@@ -215,8 +215,9 @@ func HelpProvider(epa *tiexternalplugins.ConfigAgent) externalplugins.ExternalPl
 			Snippet:     yamlSnippet,
 			Commands: []pluginhelp.Command{
 				{
-					Usage: "/[run-]check-issue-triage-complete",
+					Usage: "/retest|[run-]check-issue-triage-complete",
 					Examples: []string{
+						"/retest",
 						"/run-check-issue-triage-complete",
 						"/check-issue-triage-complete",
 					},


### PR DESCRIPTION
This pull request includes several changes to improve the `issue-triage` plugin's functionality and update related documentation. The most important changes include adding the `/retest` command to trigger issue triage checks, modifying regular expressions, and updating documentation for consistency.

Enhancements to `issue-triage` plugin:

* Updated the `checkIssueTriagedRe` regular expression to include the `/retest` command in `issuetriage.go`.
* Modified the `HelpProvider` function to include the `/retest` command in the usage and examples in `issuetriage.go`.

Configuration updates:

* Added the `/retest` command to the `message` field in `ti-community-label-blocker` configuration in `external_plugins_config.yaml`.
* Corrected the `regexp` field formatting in `ti-community-format-checker` configuration in `external_plugins_config.yaml`.

Documentation updates:

* Updated the English and Chinese documentation to include the `/retest` command as an alternative to trigger the issue triage check in `issue-triage.md`. [[1]](diffhunk://#diff-0e774f9b01e4f8ac34343db75f11d6e4bc4b560a9881832c738ddbe89e84ea4aL29-R29) [[2]](diffhunk://#diff-6faba307e172740e2cec2edf017b9858c09bf4822b2bce9405649841d9266860L29-R29)