### PR TITLE
feat(issuetriage): support mapped cherry-pick branches

### DIFF
--- a/docs/en/plugins/issue-triage.md
+++ b/docs/en/plugins/issue-triage.md
@@ -55,6 +55,7 @@ When the `check-issue-triage-complete` check passes, the bot removes the `do-not
 | may_affects_label_prefix        | string   | The label prefix that identifies the release branch that the issue may affect       |
 | linked_issue_needs_triage_label | string   | The label that identifies the PR's associated issue that requires triage completion |
 | need_cherry_pick_label_prefix   | string   | The prefix identifying the PR's need for cherry-pick to the release branch          |
+| cherry_pick_branches             | map      | Maps a version to an exceptional cherry-pick target branch; otherwise `release-<version>` is used |
 | status_target_url               | string   | The details URL of the status check                                                 |
 
 Example:
@@ -73,6 +74,10 @@ ti-community-issue-triage:
     may_affects_label_prefix: "may-affects/"
     linked_issue_needs_triage_label: "do-not-merge/needs-triage_completed"
     need_cherry_pick_label_prefix: "needs-cherry-pick-release-"
+    # Optional exceptions for repositories whose branch names do not follow release-<version>.
+    cherry_pick_branches:
+      "25.10": "release-nextgen-20251011"
+      "26.3": "release-nextgen-202603"
     status_target_url: "https://book.prow.tidb.net/#/plugins/issue-triage"
 ```
 

--- a/docs/plugins/issue-triage.md
+++ b/docs/plugins/issue-triage.md
@@ -55,6 +55,7 @@ ti-community-issue-triage 插件将被设计来对以上流程进行管控和自
 | may_affects_label_prefix        | string   | 标识 issue 可能影响的发行分支的 label 前缀             |
 | linked_issue_needs_triage_label | string   | 标识 PR 所关联 issue 需要 triage 完成的 label          |
 | need_cherry_pick_label_prefix   | string   | 标识 PR 需要 cherry-pick 到 release 分支的前缀         |
+| cherry_pick_branches             | map      | 将版本号映射到例外的 cherry-pick 目标 branch；未配置时使用 `release-<version>` |
 | status_target_url               | string   | Status check 的详情 URL                                |
 
 例如：
@@ -73,6 +74,10 @@ ti-community-issue-triage:
     may_affects_label_prefix: "may-affects/"
     linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"
     need_cherry_pick_label_prefix: "needs-cherry-pick-release-"
+    # 可选：配置 branch 名称不遵循 release-<version> 约定时使用
+    cherry_pick_branches:
+      "25.10": "release-nextgen-20251011"
+      "26.3": "release-nextgen-202603"
     status_target_url: "https://book.prow.tidb.net/#/plugins/issue-triage"
 ```
 

--- a/internal/pkg/externalplugins/config.go
+++ b/internal/pkg/externalplugins/config.go
@@ -321,6 +321,9 @@ type TiCommunityIssueTriage struct {
 	NeedTriagedLabel string `json:"linked_issue_needs_triage_label"`
 	// NeedCherryPickLabelPrefix is the prefix of label indicates that pr needs to be cherry-picked.
 	NeedCherryPickLabelPrefix string `json:"need_cherry_pick_label_prefix"`
+	// CherryPickBranches maps a release version to an exceptional target branch.
+	// When absent, the target branch keeps the existing release-<version> convention.
+	CherryPickBranches map[string]string `json:"cherry_pick_branches,omitempty"`
 	// StatusTargetURL specify the URL of status details, and more detailed descriptions or guidelines
 	// can be added on the page targeted by the URL.
 	StatusTargetURL string `json:"status_target_url"`

--- a/internal/pkg/externalplugins/issuetriage/issuetriage.go
+++ b/internal/pkg/externalplugins/issuetriage/issuetriage.go
@@ -601,7 +601,7 @@ func (s *Server) addCherryPickLabelsToPR(
 			continue
 		}
 
-		cherryPickLabel := cfg.NeedCherryPickLabelPrefix + affectVersion
+		cherryPickLabel := cherryPickLabelForVersion(affectVersion, cfg)
 		if !prLabels.Has(cherryPickLabel) {
 			labelsNeedToAdd = append(labelsNeedToAdd, cherryPickLabel)
 		}
@@ -611,6 +611,22 @@ func (s *Server) addCherryPickLabelsToPR(
 		return nil
 	}
 	return s.GitHubClient.AddLabels(org, repo, num, labelsNeedToAdd...)
+}
+
+func cherryPickLabelForVersion(version string, cfg *tiexternalplugins.TiCommunityIssueTriage) string {
+	branch, ok := cfg.CherryPickBranches[version]
+	if !ok || strings.TrimSpace(branch) == "" {
+		return cfg.NeedCherryPickLabelPrefix + version
+	}
+
+	branch = strings.TrimSpace(branch)
+	labelPrefix := cfg.NeedCherryPickLabelPrefix
+	// The existing configuration commonly ends in "release-", while the
+	// exception map stores the complete target branch name.
+	if strings.HasSuffix(labelPrefix, "release-") {
+		labelPrefix = strings.TrimSuffix(labelPrefix, "release-")
+	}
+	return labelPrefix + branch
 }
 
 // isPRNeedToCheck used to determine if PR needs to be checked.

--- a/internal/pkg/externalplugins/issuetriage/issuetriage.go
+++ b/internal/pkg/externalplugins/issuetriage/issuetriage.go
@@ -623,9 +623,7 @@ func cherryPickLabelForVersion(version string, cfg *tiexternalplugins.TiCommunit
 	labelPrefix := cfg.NeedCherryPickLabelPrefix
 	// The existing configuration commonly ends in "release-", while the
 	// exception map stores the complete target branch name.
-	if strings.HasSuffix(labelPrefix, "release-") {
-		labelPrefix = strings.TrimSuffix(labelPrefix, "release-")
-	}
+	labelPrefix = strings.TrimSuffix(labelPrefix, "release-")
 	return labelPrefix + branch
 }
 

--- a/internal/pkg/externalplugins/issuetriage/issuetriage_test.go
+++ b/internal/pkg/externalplugins/issuetriage/issuetriage_test.go
@@ -1985,3 +1985,68 @@ func TestHelpProvider(t *testing.T) {
 		})
 	}
 }
+
+func TestCherryPickLabelForVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		prefix   string
+		branches map[string]string
+		want     string
+	}{
+		{
+			name:    "keeps the existing release convention",
+			version: "8.5",
+			want:    "needs-cherry-pick-release-8.5",
+		},
+		{
+			name:    "maps an exceptional nextgen branch",
+			version: "26.3",
+			branches: map[string]string{
+				"26.3": "release-nextgen-202603",
+			},
+			want: "needs-cherry-pick-release-nextgen-202603",
+		},
+		{
+			name:    "supports a prefix without release suffix",
+			version: "26.3",
+			prefix:  "needs-cherry-pick-",
+			branches: map[string]string{
+				"26.3": "release-nextgen-202603",
+			},
+			want: "needs-cherry-pick-release-nextgen-202603",
+		},
+		{
+			name:    "supports a non-release target branch",
+			version: "26.3",
+			branches: map[string]string{
+				"26.3": "master",
+			},
+			want: "needs-cherry-pick-master",
+		},
+		{
+			name:    "ignores an empty mapping",
+			version: "8.5",
+			branches: map[string]string{
+				"8.5": " ",
+			},
+			want: "needs-cherry-pick-release-8.5",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			prefix := tc.prefix
+			if prefix == "" {
+				prefix = "needs-cherry-pick-release-"
+			}
+			cfg := &externalplugins.TiCommunityIssueTriage{
+				NeedCherryPickLabelPrefix: prefix,
+				CherryPickBranches:        tc.branches,
+			}
+			if got := cherryPickLabelForVersion(tc.version, cfg); got != tc.want {
+				t.Fatalf("cherryPickLabelForVersion() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- add optional `cherry_pick_branches` mappings for repositories whose release branch names are exceptional
- preserve the existing `release-<version>` behavior when no mapping is configured
- add tests and update issue-triage documentation

This pairs with ti-community-infra/configs#1290 for the NextGen 25.10 and 26.3 configuration.